### PR TITLE
Adding trigger method tag to the snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ python3 test_br.py                     \
   --instance_id=<vm-XXXX-XXXX>         \
   --container=<google-cloud-container> \
   --job_name=<name>                    \
+  --trigger=<on-demand/scheduled>      \
   --credentials="$credential_json"     \
   --projectId=<project id>             \
   --secret=<secret>
@@ -104,6 +105,7 @@ python3 backup.py                  \
   --secret=<secret>                \
   --container=<container>          \
   --job_name=<name>                \
+  --trigger=<on-demand/scheduled>  \
   --tenant_id=<tenant-id>          \
   --tenant_name=<tenant-name>      \
   --auth_url=<auth-url>            \
@@ -123,6 +125,7 @@ python3 test_br.py                     \
   --secret=xxxxxxxx                    \
   --container=<container>              \
   --job_name=<name>                    \
+  --trigger=<on-demand/scheduled>      \
   --access_key_id=<key>                \
   --secret_access_key=<accesskey>      \
   --region_name=<region>
@@ -139,6 +142,7 @@ python3 test_br.py                     \
   --secret=xxxxxxxx                    \
   --container=<container>              \
   --job_name=<name>                    \
+  --trigger=<on-demand/scheduled>      \
   --access_key_id=<key>                \
   --secret_access_key=<accesskey>      \
   --region_name=<region>               \

--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -24,10 +24,12 @@ class BaseClient:
             self.INSTANCE_ID = configuration['instance_id']
             self.SECRET = configuration['secret']
             self.JOB_NAME = configuration['job_name']
+            self.TRIGGER = configuration['trigger']
             self.tags = {
                 'created_by': 'service-fabrik-backup-restore',
                 'instance_id': self.INSTANCE_ID,
-                'job_name': self.JOB_NAME
+                'job_name': self.JOB_NAME,
+                'trigger': self.TRIGGER
                 }
         else:
             self.BLOB_PREFIX = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' + str(time.time())

--- a/lib/config.py
+++ b/lib/config.py
@@ -60,7 +60,8 @@ parameters_backup = {
     'instance_id': 'the ID of the AWS/OpenStack instance to be backed up',
     'secret': 'the password used for the encryption of the backup set',
     'container': 'a container in the object storage in which the backup set can be stored',
-    'job_name': 'the name of the service job under which it is registered to monit'
+    'job_name': 'the name of the service job under which it is registered to monit',
+    'trigger': 'the trigger method of backup on-demand/scheduled'
 }
 
 parameters_restore = {

--- a/tests/test_clients_AliClient.py
+++ b/tests/test_clients_AliClient.py
@@ -33,6 +33,7 @@ configuration = {
     'instance_id' : 'vm-id',
     'secret' : 'xyz',
     'job_name' : 'service-job-name',
+    'trigger' : 'on-demand-or-scheduled',
     'container' : valid_container,
     'access_key_id' : access_key,
     'secret_access_key' : secret_access_key,

--- a/tests/test_clients_AwsClient.py
+++ b/tests/test_clients_AwsClient.py
@@ -33,6 +33,7 @@ configuration = {
     'instance_id' : 'vm-id',
     'secret' : 'xyz',
     'job_name' : 'service-job-name',
+    'trigger' : 'on-demand-or-scheduled',
     'container' : valid_container,
     'access_key_id' : 'key-id',
     'secret_access_key' : 'secret-key',

--- a/tests/test_clients_GcpClient.py
+++ b/tests/test_clients_GcpClient.py
@@ -28,6 +28,7 @@ configuration = {
     'instance_id': 'vm-id',
     'secret': 'xyz',
     'job_name': 'service-job-name',
+    'trigger' : 'on-demand-or-scheduled',
     'container': valid_container,
     'projectId': project_id,
     'credentials': '{ "type": "service_account", "project_id": "gcp-dev", "client_id": "123", "private_key_id": "2222",  "private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEFatI0=\\n-----END PRIVATE KEY-----\\n", "client_email": "user@gcp-dev.com", "client_id": "6666", "auth_uri": "auth_uri", "token_uri": "token_uri", "auth_provider_x509_cert_url": "cert_url", "client_x509_cert_url": "cert_url"  }'
@@ -774,6 +775,7 @@ class TestGcpClient:
             'instance_id': 'vm-id',
             'secret': 'xyz',
             'job_name': 'service-job-name',
+            'trigger' : 'on-demand-or-scheduled',
             'container': valid_container,
             'projectId': project_id,
             'credhub_url': '/credhub',

--- a/tests/test_clients_OpenstackClient.py
+++ b/tests/test_clients_OpenstackClient.py
@@ -28,6 +28,7 @@ configuration = {
     'instance_id': 'vm-id',
     'secret': 'xyz',
     'job_name': 'service-job-name',
+    'trigger' : 'on-demand-or-scheduled',
     'container': valid_container,
     'projectId': project_id,
     'username': 'name',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,8 @@ ops_parameters = {
         'instance_id': 'valid-instance-id',
         'secret': 'valid-secret',
         'container': 'valid-container-name',
-        'job_name': 'valid-job-name'
+        'job_name': 'valid-job-name',
+        'trigger' : 'on-demand-or-scheduled'
     },
     'restore': {
         'backup_guid': 'valid-backup-guid',
@@ -106,6 +107,7 @@ class TestConfig():
         assert configuration['secret'] == ops_parameters['backup']['secret']
         assert configuration['container'] == ops_parameters['backup']['container']
         assert configuration['job_name'] == ops_parameters['backup']['job_name']
+        assert configuration['trigger'] == ops_parameters['backup']['trigger']
 
     def test_build_parser_restore(self):
         #build the parser for restore


### PR DESCRIPTION
This pull request adds a new mandatory command line parameter `--trigger` to backup operation.  The trigger parameter expects value as `on-demand` or `scheduled`. The cron jobs are expected to pass the arguments as `scheduled`.
The argument of `--trigger` parameter is then passed as a tag of the backup snapshot. Use `--trigger`  as `on-demand` by default.